### PR TITLE
Add PDF export functionality

### DIFF
--- a/src/components/Reports/AnnualReport.tsx
+++ b/src/components/Reports/AnnualReport.tsx
@@ -30,6 +30,12 @@ ChartJS.register(
 const AnnualReport: React.FC = () => {
   const { getAnnualReport, exportToPDF } = useAppContext();
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+  const [pdfLink, setPdfLink] = useState<string | null>(null);
+
+  const handleExport = async () => {
+    const url = await exportToPDF();
+    if (url) setPdfLink(url);
+  };
   
   const report = getAnnualReport(selectedYear);
   const currentYear = new Date().getFullYear();
@@ -171,7 +177,7 @@ const AnnualReport: React.FC = () => {
   };
 
   return (
-    <div className="p-6 max-w-7xl mx-auto">
+    <div id="annual-report" className="p-6 max-w-7xl mx-auto">
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-3xl font-bold text-gray-900 mb-2">📊 Bilan Annuel</h1>
@@ -190,12 +196,22 @@ const AnnualReport: React.FC = () => {
           </select>
           
           <button
-            onClick={exportToPDF}
+            onClick={handleExport}
             className="flex items-center space-x-2 bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors"
           >
             <Download className="h-4 w-4" />
-            <span>Export PDF</span>
+            <span>Télécharger PDF</span>
           </button>
+          {pdfLink && (
+            <a
+              href={pdfLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline text-sm"
+            >
+              Ouvrir le PDF
+            </a>
+          )}
         </div>
       </div>
 

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,4 +1,6 @@
 import React, { createContext, useContext, useState, ReactNode } from 'react';
+import jsPDF from 'jspdf';
+import html2canvas from 'html2canvas';
 import { Client, Invoice, Cost, User, MonthlyData, AnnualReport, MonthlyClientData } from '../types';
 import { format, subMonths, getMonth, getYear } from 'date-fns';
 
@@ -33,7 +35,7 @@ interface AppContextType {
   getClientProfit: (clientId: string) => number;
   getClientMonthlyData: (clientId: string) => MonthlyClientData[];
   getAnnualReport: (year: number) => AnnualReport;
-  exportToPDF: () => void;
+  exportToPDF: () => Promise<string | void>;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -444,10 +446,22 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     };
   };
 
-  const exportToPDF = async () => {
-    // This would implement PDF export functionality
-    // For now, we'll show an alert
-    alert('Fonctionnalité d\'export PDF en cours de développement');
+  const exportToPDF = async (): Promise<string | void> => {
+    const element = document.getElementById('annual-report');
+    if (!element) return;
+
+    const canvas = await html2canvas(element, { scale: 2 });
+    const imgData = canvas.toDataURL('image/png');
+
+    const pdf = new jsPDF({
+      orientation: 'portrait',
+      unit: 'px',
+      format: [canvas.width, canvas.height]
+    });
+
+    pdf.addImage(imgData, 'PNG', 0, 0, canvas.width, canvas.height);
+    const pdfUrl = pdf.output('bloburl');
+    return pdfUrl;
   };
 
   const value: AppContextType = {


### PR DESCRIPTION
## Summary
- implement PDF export with `jspdf` and `html2canvas`
- wrap annual report in `annual-report` DOM node and expose download link
- tweak UI text to mention download

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684485001ebc832d95ccb608d6c55f8c