### PR TITLE
Add standard .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Node dependencies
+node_modules/
+
+# Build output
+/dist/
+build/
+
+# Editor directories and OS files
+.DS_Store
+Thumbs.db
+*.log
+*.tmp
+*.swp
+*~
+
+# Misc
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+


### PR DESCRIPTION
## Summary
- ignore `node_modules/`
- ignore build output in `dist/` and `build/`
- ignore common editor and OS temporary files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846e565adbc832d906f9e6378ff3ade