### PR TITLE
Fix pending invoice sum in dashboard

### DIFF
--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -28,7 +28,7 @@ const Dashboard: React.FC = () => {
   const profitMargin = totalRevenue > 0 ? ((totalProfit / totalRevenue) * 100) : 0;
 
   const pendingInvoices = invoices.filter(inv => inv.status === 'pending');
-  const pendingAmount = pendingInvoices.reduce((sum, inv) => sum + inv.amount, 0);
+  const pendingAmount = pendingInvoices.reduce((sum, inv) => sum + inv.amountTTC, 0);
 
   return (
     <div className="p-6 max-w-7xl mx-auto text-gray-900 dark:text-gray-100">


### PR DESCRIPTION
## Summary
- compute pending invoice total using existing amountTTC field

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e579097c832db944eef5b88b67a9