### PR TITLE
Add invoice status chart

### DIFF
--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -10,6 +10,7 @@ import {
 import StatsCard from './StatsCard';
 import RevenueChart from './RevenueChart';
 import ProfitChart from './ProfitChart';
+import InvoiceStatusChart from './InvoiceStatusChart';
 import ClientsList from './ClientsList';
 import { useAppContext } from '../../context/AppContext';
 
@@ -77,7 +78,7 @@ const Dashboard: React.FC = () => {
       </div>
 
       {/* Charts */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
         <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6">
           <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
             Évolution du Chiffre d'Affaires
@@ -90,6 +91,13 @@ const Dashboard: React.FC = () => {
             Analyse des Bénéfices
           </h2>
           <ProfitChart />
+        </div>
+
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm p-6">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4">
+            Statut des Factures
+          </h2>
+          <InvoiceStatusChart />
         </div>
       </div>
 

--- a/src/components/Dashboard/InvoiceStatusChart.tsx
+++ b/src/components/Dashboard/InvoiceStatusChart.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import { Doughnut } from 'react-chartjs-2';
+import { useAppContext } from '../../context/AppContext';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+const InvoiceStatusChart: React.FC = () => {
+  const { invoices } = useAppContext();
+
+  const statusCounts = {
+    paid: invoices.filter(inv => inv.status === 'paid').length,
+    pending: invoices.filter(inv => inv.status === 'pending').length,
+    overdue: invoices.filter(inv => inv.status === 'overdue').length
+  };
+
+  const data = {
+    labels: ['Payées', 'En attente', 'En retard'],
+    datasets: [
+      {
+        data: [statusCounts.paid, statusCounts.pending, statusCounts.overdue],
+        backgroundColor: ['#10B981', '#F59E0B', '#EF4444'],
+        borderColor: ['#10B981', '#F59E0B', '#EF4444'],
+        borderWidth: 2
+      }
+    ]
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        position: 'bottom' as const,
+        labels: {
+          usePointStyle: true,
+          padding: 20,
+          font: {
+            size: 12,
+            weight: '500'
+          }
+        }
+      },
+      tooltip: {
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        titleColor: '#ffffff',
+        bodyColor: '#ffffff',
+        borderColor: '#e5e7eb',
+        borderWidth: 1,
+        cornerRadius: 8,
+        displayColors: true,
+        callbacks: {
+          label: function(context: any) {
+            const label = context.label || '';
+            const value = context.parsed;
+            return `${label}: ${value}`;
+          }
+        }
+      }
+    }
+  };
+
+  return (
+    <div className="h-80">
+      <Doughnut data={data} options={options} />
+    </div>
+  );
+};
+
+export default InvoiceStatusChart;


### PR DESCRIPTION
## Summary
- visualize invoice status distribution with a new `InvoiceStatusChart`
- import and display the new chart on the dashboard

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846e57ce788832db16be5a0fd4a9543