### PR TITLE
Fix lucide-react import in StatsCard

### DIFF
--- a/src/components/Dashboard/StatsCard.tsx
+++ b/src/components/Dashboard/StatsCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DivideIcon as LucideIcon } from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
 interface StatsCardProps {
   title: string;


### PR DESCRIPTION
## Summary
- update StatsCard to import `LucideIcon` only as a type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846e57bc9a8832da06ab814eea0734e