### PR TITLE
Refine date revival helper

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -48,6 +48,17 @@ export const useAppContext = () => {
   return context;
 };
 
+function reviveDates<T extends Record<string, unknown>>(obj: T, keys: (keyof T)[]): T {
+  const copy = { ...obj };
+  for (const key of keys) {
+    const value = copy[key];
+    if (typeof value === 'string' || typeof value === 'number') {
+      (copy as Record<string, unknown>)[key] = new Date(value);
+    }
+  }
+  return copy as T;
+}
+
 export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [currentUser, setCurrentUser] = useState<User | null>({
     id: '1',
@@ -62,10 +73,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     if (stored) {
       try {
         const parsed: Client[] = JSON.parse(stored);
-        return parsed.map(c => ({
-          ...c,
-          createdAt: new Date(c.createdAt)
-        }));
+        return parsed.map(c => reviveDates(c, ['createdAt']));
       } catch {
         // ignore parsing errors and fallback to defaults
       }
@@ -115,11 +123,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     if (stored) {
       try {
         const parsed: Invoice[] = JSON.parse(stored);
-        return parsed.map(inv => ({
-          ...inv,
-          issueDate: new Date(inv.issueDate),
-          dueDate: new Date(inv.dueDate)
-        }));
+        return parsed.map(inv => reviveDates(inv, ['issueDate', 'dueDate']));
       } catch {
         // ignore parsing errors
       }
@@ -198,10 +202,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     if (stored) {
       try {
         const parsed: Cost[] = JSON.parse(stored);
-        return parsed.map(cost => ({
-          ...cost,
-          date: new Date(cost.date)
-        }));
+        return parsed.map(cost => reviveDates(cost, ['date']));
       } catch {
         // ignore parsing errors
       }


### PR DESCRIPTION
## Summary
- improve reviveDates helper to safely convert string dates
- keep file with newline at end of file

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846e5640674832dbc0d1857c4cee44a