### PR TITLE
Add view selector in header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,8 @@ function App() {
           onMenuToggle={() => setSidebarOpen(!sidebarOpen)}
           theme={theme}
           onThemeToggle={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          activeView={activeView}
+          onViewChange={setActiveView}
         />
         
         <div className="flex">
@@ -62,7 +64,7 @@ function App() {
             onViewChange={setActiveView}
           />
           
-          <main className="flex-1 lg:ml-64">
+          <main className="flex-1 lg:ml-64 mx-auto max-w-7xl p-6">
             {renderActiveView()}
           </main>
         </div>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -6,9 +6,11 @@ interface HeaderProps {
   onMenuToggle: () => void;
   theme: 'light' | 'dark';
   onThemeToggle: () => void;
+  activeView: string;
+  onViewChange: (view: string) => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ onMenuToggle, theme, onThemeToggle }) => {
+const Header: React.FC<HeaderProps> = ({ onMenuToggle, theme, onThemeToggle, activeView, onViewChange }) => {
   const { currentUser, setCurrentUser } = useAppContext();
 
   const handleRoleToggle = () => {
@@ -37,6 +39,15 @@ const Header: React.FC<HeaderProps> = ({ onMenuToggle, theme, onThemeToggle }) =
         </div>
 
         <div className="flex items-center space-x-4">
+          <select
+            value={activeView}
+            onChange={(e) => onViewChange(e.target.value)}
+            className="border border-gray-300 dark:border-gray-600 rounded-md p-2 text-sm bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-200"
+          >
+            <option value="invoices">Factures</option>
+            <option value="costs">Coûts</option>
+            <option value="clients">Clients</option>
+          </select>
           <div className="flex items-center space-x-2">
             <span className="text-sm text-gray-600 dark:text-gray-400">Mode:</span>
             <button


### PR DESCRIPTION
## Summary
- add view selector dropdown in `Header`
- pass active view props from `App` and center the main layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472644582c832d94823fe3144c2a5c