### PR TITLE
Add view selector and tidy layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,8 @@ function App() {
           onMenuToggle={() => setSidebarOpen(!sidebarOpen)}
           theme={theme}
           onThemeToggle={() => setTheme(theme === 'light' ? 'dark' : 'light')}
+          activeView={activeView}
+          onViewChange={setActiveView}
         />
         
         <div className="flex">
@@ -62,7 +64,7 @@ function App() {
             onViewChange={setActiveView}
           />
           
-          <main className="flex-1 lg:ml-64">
+          <main className="flex-1 lg:ml-64 mx-auto max-w-7xl p-4">
             {renderActiveView()}
           </main>
         </div>

--- a/src/components/Analytics/ClientAnalytics.tsx
+++ b/src/components/Analytics/ClientAnalytics.tsx
@@ -145,7 +145,7 @@ const ClientAnalytics: React.FC = () => {
   const averageMargin = totalRevenue > 0 ? (totalProfit / totalRevenue) * 100 : 0;
 
   return (
-    <div className="p-6 max-w-7xl mx-auto">
+    <div className="p-6">
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-3xl font-bold text-gray-900 mb-2">📈 Analytics par Client</h1>

--- a/src/components/Clients/ClientsManager.tsx
+++ b/src/components/Clients/ClientsManager.tsx
@@ -34,7 +34,7 @@ const ClientsManager: React.FC = () => {
   };
 
   return (
-    <div className="p-6 max-w-7xl mx-auto">
+    <div className="p-6">
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-3xl font-bold text-gray-900 mb-2">Gestion des Clients</h1>

--- a/src/components/Costs/CostsManager.tsx
+++ b/src/components/Costs/CostsManager.tsx
@@ -58,7 +58,7 @@ const CostsManager: React.FC = () => {
   const totalAmount = filteredCosts.reduce((sum, cost) => sum + cost.amount, 0);
 
   return (
-    <div className="p-6 max-w-7xl mx-auto">
+    <div className="p-6">
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-3xl font-bold text-gray-900 mb-2">🟦 Gestion des Coûts</h1>

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -35,7 +35,7 @@ const Dashboard: React.FC = () => {
   );
 
   return (
-    <div className="p-6 max-w-7xl mx-auto text-gray-900 dark:text-gray-100">
+    <div className="p-6 text-gray-900 dark:text-gray-100">
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2">Tableau de Bord</h1>
         <p className="text-gray-600 dark:text-gray-400">Vue d'ensemble de votre activité</p>

--- a/src/components/Invoices/InvoiceForm.tsx
+++ b/src/components/Invoices/InvoiceForm.tsx
@@ -161,9 +161,9 @@ const InvoiceForm: React.FC<InvoiceFormProps> = ({ invoice, onClose }) => {
               onChange={(e) => setFormData({ ...formData, status: e.target.value as any })}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
-              <option value="pending">🟥 En attente</option>
-              <option value="paid">🟩 Payée</option>
-              <option value="overdue">🟥 En retard</option>
+              <option value="pending">En attente</option>
+              <option value="paid">Payée</option>
+              <option value="overdue">En retard</option>
             </select>
           </div>
 

--- a/src/components/Invoices/InvoicesManager.tsx
+++ b/src/components/Invoices/InvoicesManager.tsx
@@ -60,9 +60,9 @@ const InvoicesManager: React.FC = () => {
 
   const getStatusLabel = (status: string) => {
     switch (status) {
-      case 'paid': return '🟩 Payée';
-      case 'pending': return '🟥 En attente';
-      case 'overdue': return '🟥 En retard';
+      case 'paid': return 'Payée';
+      case 'pending': return 'En attente';
+      case 'overdue': return 'En retard';
       default: return status;
     }
   };
@@ -73,10 +73,10 @@ const InvoicesManager: React.FC = () => {
   const paidAmountHT = filteredInvoices.filter(inv => inv.status === 'paid').reduce((sum, inv) => sum + inv.amountHT, 0);
 
   return (
-    <div className="p-6 max-w-7xl mx-auto">
+    <div className="p-6">
       <div className="flex items-center justify-between mb-8">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">🟥 Gestion des Factures</h1>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">Gestion des Factures</h1>
           <div className="text-gray-600 space-y-1">
             <p>{filteredInvoices.length} facture(s)</p>
             <p>Total HT: {totalAmountHT.toLocaleString('fr-FR')} € • TVA: {totalTVA.toLocaleString('fr-FR')} € • TTC: {totalTTC.toLocaleString('fr-FR')} €</p>
@@ -157,9 +157,9 @@ const InvoicesManager: React.FC = () => {
           className="px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
         >
           <option value="all">Tous les statuts</option>
-          <option value="pending">🟥 En attente</option>
-          <option value="paid">🟩 Payées</option>
-          <option value="overdue">🟥 En retard</option>
+          <option value="pending">En attente</option>
+          <option value="paid">Payées</option>
+          <option value="overdue">En retard</option>
         </select>
       </div>
 
@@ -231,9 +231,9 @@ const InvoicesManager: React.FC = () => {
                         onChange={(e) => handleStatusChange(invoice.id, e.target.value as any)}
                         className={`text-xs font-medium px-3 py-1 rounded-full border-0 ${getStatusColor(invoice.status)}`}
                       >
-                        <option value="pending">🟥 En attente</option>
-                        <option value="paid">🟩 Payée</option>
-                        <option value="overdue">🟥 En retard</option>
+                        <option value="pending">En attente</option>
+                        <option value="paid">Payée</option>
+                        <option value="overdue">En retard</option>
                       </select>
                     ) : (
                       <span className={`inline-flex items-center space-x-1 text-xs font-medium px-3 py-1 rounded-full ${getStatusColor(invoice.status)}`}>

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -6,9 +6,17 @@ interface HeaderProps {
   onMenuToggle: () => void;
   theme: 'light' | 'dark';
   onThemeToggle: () => void;
+  activeView: string;
+  onViewChange: (view: string) => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ onMenuToggle, theme, onThemeToggle }) => {
+const Header: React.FC<HeaderProps> = ({
+  onMenuToggle,
+  theme,
+  onThemeToggle,
+  activeView,
+  onViewChange
+}) => {
   const { currentUser, setCurrentUser } = useAppContext();
 
   const handleRoleToggle = () => {
@@ -61,6 +69,16 @@ const Header: React.FC<HeaderProps> = ({ onMenuToggle, theme, onThemeToggle }) =
               <Moon className="h-5 w-5 text-gray-600 dark:text-gray-300" />
             )}
           </button>
+
+          <select
+            value={activeView}
+            onChange={(e) => onViewChange(e.target.value)}
+            className="p-2 rounded-md border"
+          >
+            <option value="invoices">Factures</option>
+            <option value="costs">Coûts</option>
+            <option value="clients">Clients</option>
+          </select>
 
           <div className="flex items-center space-x-2 px-3 py-2 bg-gray-50 dark:bg-gray-700 rounded-lg">
             <User className="h-4 w-4 text-gray-600 dark:text-gray-300" />

--- a/src/components/Reports/AnnualReport.tsx
+++ b/src/components/Reports/AnnualReport.tsx
@@ -177,7 +177,7 @@ const AnnualReport: React.FC = () => {
   };
 
   return (
-    <div id="annual-report" className="p-6 max-w-7xl mx-auto">
+    <div id="annual-report" className="p-6">
       <div className="flex items-center justify-between mb-8">
         <div>
           <h1 className="text-3xl font-bold text-gray-900 mb-2">📊 Bilan Annuel</h1>


### PR DESCRIPTION
## Summary
- add view selection dropdown in header
- feed active view props from `App`
- center main container and clean up page containers
- simplify invoice status labels

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847261b1e30832d88ffae0ed6130055