### PR TITLE
Update client analytics to full 2025 range

### DIFF
--- a/src/components/Analytics/ClientAnalytics.tsx
+++ b/src/components/Analytics/ClientAnalytics.tsx
@@ -30,9 +30,9 @@ const ClientAnalytics: React.FC = () => {
   const [selectedClientId, setSelectedClientId] = useState(clients[0]?.id || '');
   
   const selectedClient = clients.find(c => c.id === selectedClientId);
-  // Limit to the last 12 months to display a full year of data
+  // Display data for the entire year 2025
   const monthlyData = selectedClient
-    ? getClientMonthlyData(selectedClientId).slice(-12)
+    ? getClientMonthlyData(selectedClientId, 2025)
     : [];
 
   const chartData = {

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -44,7 +44,7 @@ interface AppContextType {
   getTotalCosts: () => number;
   getTotalProfit: () => number;
   getClientProfit: (clientId: string) => number;
-  getClientMonthlyData: (clientId: string) => MonthlyClientData[];
+  getClientMonthlyData: (clientId: string, year?: number) => MonthlyClientData[];
   getAnnualReport: (year: number) => AnnualReport;
   exportToPDF: () => Promise<string | void>;
 }
@@ -402,20 +402,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     return revenue - totalCosts;
   };
 
-  const getClientMonthlyData = (clientId: string): MonthlyClientData[] => {
-    const startDate = new Date(2025, 0, 1);
-
-    const lastInvoiceDate = invoices
-      .filter(inv => inv.clientId === clientId)
-      .reduce((latest, inv) => (inv.issueDate > latest ? inv.issueDate : latest), new Date(0));
-
-    const lastCostDate = costs
-      .filter(cost => cost.clientId === clientId)
-      .reduce((latest, cost) => (cost.date > latest ? cost.date : latest), new Date(0));
-
-    const now = new Date();
-    let endDate = new Date(Math.max(lastInvoiceDate.getTime(), lastCostDate.getTime(), now.getTime()));
-    endDate = new Date(endDate.getFullYear(), endDate.getMonth(), 1);
+  const getClientMonthlyData = (clientId: string, year = 2025): MonthlyClientData[] => {
+    const startDate = new Date(year, 0, 1);
+    const endDate = new Date(year, 11, 1);
 
     const months: { month: string; year: number }[] = [];
     let current = new Date(startDate);


### PR DESCRIPTION
## Summary
- show 2025 data for client analytics
- update context method to accept a year parameter

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68483e80401c832db7e28839d4f97088