### PR TITLE
Implement secure admin switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ La barre latérale donne accès aux différentes pages :
 - Calcul automatique du chiffre d'affaires, des marges et du bénéfice.
 - Visualisation des performances par client et par période.
 - Export du rapport annuel en PDF.
+- Mode sécurisé : l'application démarre en mode "Visualisation". Cliquez sur le
+  bouton "Mode" pour passer administrateur et saisissez le mot de passe
+  **THABARY**.
 
 ## Licence
 

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -14,11 +14,16 @@ const Header: React.FC<HeaderProps> = ({ onMenuToggle, theme, onThemeToggle, act
   const { currentUser, setCurrentUser } = useAppContext();
 
   const handleRoleToggle = () => {
-    if (currentUser) {
-      setCurrentUser({
-        ...currentUser,
-        role: currentUser.role === 'admin' ? 'viewer' : 'admin'
-      });
+    if (!currentUser) return;
+    if (currentUser.role === 'admin') {
+      setCurrentUser({ ...currentUser, role: 'viewer' });
+    } else {
+      const pwd = window.prompt('Entrez le mot de passe administrateur');
+      if (pwd === 'THABARY') {
+        setCurrentUser({ ...currentUser, role: 'admin' });
+      } else if (pwd !== null) {
+        alert('Mot de passe incorrect');
+      }
     }
   };
 

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -64,7 +64,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     id: '1',
     name: 'Admin User',
     email: 'admin@maintup.fr',
-    role: 'admin'
+    role: 'viewer'
   });
 
   // Données chargées depuis l'API backend ou le localStorage


### PR DESCRIPTION
## Summary
- default to `viewer` role on startup
- require password `THABARY` to switch to admin in the header
- document secure mode in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848aa3f457c832d894a0619492af0da