### PR TITLE
Ajout catégorie Logements

### DIFF
--- a/src/components/Costs/CostForm.tsx
+++ b/src/components/Costs/CostForm.tsx
@@ -15,7 +15,7 @@ const CostForm: React.FC<CostFormProps> = ({ cost, onClose }) => {
     invoiceId: cost?.invoiceId || '',
     description: cost?.description || '',
     amount: cost?.amount || 0,
-    category: cost?.category || 'materials' as 'salaries' | 'charges' | 'subcontracting' | 'materials' | 'transport' | 'other',
+    category: cost?.category || 'materials' as 'salaries' | 'charges' | 'subcontracting' | 'materials' | 'transport' | 'housing' | 'other',
     date: cost?.date ? cost.date.toISOString().split('T')[0] : new Date().toISOString().split('T')[0]
   });
 
@@ -48,6 +48,7 @@ const CostForm: React.FC<CostFormProps> = ({ cost, onClose }) => {
     { id: 'subcontracting', label: '🤝 Sous-traitance', color: 'text-green-600' },
     { id: 'materials', label: '🔧 Matériaux', color: 'text-orange-600' },
     { id: 'transport', label: '🚛 Transport', color: 'text-yellow-600' },
+    { id: 'housing', label: '🏠 Logements', color: 'text-teal-600' },
     { id: 'other', label: '📋 Autre', color: 'text-gray-600' },
   ];
 

--- a/src/components/Costs/CostsManager.tsx
+++ b/src/components/Costs/CostsManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Plus, Search, DollarSign, Users, FileText, Truck, Wrench, BarChart3 } from 'lucide-react';
+import { Plus, Search, DollarSign, Users, FileText, Truck, Wrench, BarChart3, Home } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
 import CostForm from './CostForm';
 import { Cost } from '../../types';
@@ -18,6 +18,7 @@ const CostsManager: React.FC = () => {
     { id: 'subcontracting', label: '🤝 Sous-traitance', icon: Users, color: 'text-green-600', bg: 'bg-green-50' },
     { id: 'materials', label: '🔧 Matériaux', icon: Wrench, color: 'text-orange-600', bg: 'bg-orange-50' },
     { id: 'transport', label: '🚛 Transport', icon: Truck, color: 'text-yellow-600', bg: 'bg-yellow-50' },
+    { id: 'housing', label: '🏠 Logements', icon: Home, color: 'text-teal-600', bg: 'bg-teal-50' },
     { id: 'other', label: '📋 Autre', icon: FileText, color: 'text-gray-600', bg: 'bg-gray-50' },
   ];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,7 +32,7 @@ export interface Cost {
   invoiceId?: string;
   description: string;
   amount: number;
-  category: 'salaries' | 'charges' | 'subcontracting' | 'materials' | 'transport' | 'other';
+  category: 'salaries' | 'charges' | 'subcontracting' | 'materials' | 'transport' | 'housing' | 'other';
   date: Date;
 }
 


### PR DESCRIPTION
## Notes
- ESLint ne s'exécute pas car certaines dépendances sont absentes dans l'environnement

## Summary
- ajout de `housing` dans le type `Cost`
- mise à jour du formulaire de coûts avec la catégorie Logements
- mise à jour du gestionnaire de coûts et import de l'icône Home


------
https://chatgpt.com/codex/tasks/task_e_68490eb2f758832d9f2d992127c77a9a