### PR TITLE
Fix client revenue display

### DIFF
--- a/src/components/Clients/ClientsManager.tsx
+++ b/src/components/Clients/ClientsManager.tsx
@@ -5,7 +5,7 @@ import ClientForm from './ClientForm';
 import { Client } from '../../types';
 
 const ClientsManager: React.FC = () => {
-  const { clients, currentUser, deleteClient, getClientProfit } = useAppContext();
+  const { clients, currentUser, deleteClient, getClientProfit, getClientRevenue } = useAppContext();
   const [searchTerm, setSearchTerm] = useState('');
   const [showForm, setShowForm] = useState(false);
   const [editingClient, setEditingClient] = useState<Client | null>(null);
@@ -67,8 +67,9 @@ const ClientsManager: React.FC = () => {
       {/* Clients Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {filteredClients.map((client) => {
+          const revenue = getClientRevenue(client.id);
           const profit = getClientProfit(client.id);
-          const profitMargin = client.totalInvoices > 0 ? ((profit / client.totalInvoices) * 100) : 0;
+          const profitMargin = revenue > 0 ? ((profit / revenue) * 100) : 0;
           
           return (
             <div key={client.id} className="bg-white rounded-xl shadow-sm p-6 hover:shadow-md transition-shadow">
@@ -119,7 +120,7 @@ const ClientsManager: React.FC = () => {
                   <div>
                     <p className="text-xs text-gray-500 uppercase tracking-wide">CA Total</p>
                     <p className="text-lg font-semibold text-gray-900">
-                      {client.totalInvoices.toLocaleString('fr-FR')} €
+                      {revenue.toLocaleString('fr-FR')} €
                     </p>
                   </div>
                   <div>

--- a/src/components/Dashboard/ClientsList.tsx
+++ b/src/components/Dashboard/ClientsList.tsx
@@ -3,13 +3,19 @@ import { Building2, TrendingUp, TrendingDown } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
 
 const ClientsList: React.FC = () => {
-  const { clients, getClientProfit } = useAppContext();
+  const { clients, getClientProfit, getClientRevenue } = useAppContext();
 
-  const clientsWithProfit = clients.map(client => ({
-    ...client,
-    profit: getClientProfit(client.id),
-    profitMargin: client.totalInvoices > 0 ? ((getClientProfit(client.id) / client.totalInvoices) * 100) : 0
-  })).sort((a, b) => b.profit - a.profit);
+  const clientsWithProfit = clients.map(client => {
+    const revenue = getClientRevenue(client.id);
+    const profit = getClientProfit(client.id);
+    const profitMargin = revenue > 0 ? ((profit / revenue) * 100) : 0;
+    return {
+      ...client,
+      revenue,
+      profit,
+      profitMargin
+    };
+  }).sort((a, b) => b.profit - a.profit);
 
   return (
     <div className="space-y-4">
@@ -32,7 +38,7 @@ const ClientsList: React.FC = () => {
             <div className="text-right">
               <p className="text-sm text-gray-600 dark:text-gray-400">CA Total</p>
               <p className="font-semibold text-gray-900 dark:text-gray-100">
-                {client.totalInvoices.toLocaleString('fr-FR')} €
+                {client.revenue.toLocaleString('fr-FR')} €
               </p>
             </div>
             

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -43,6 +43,7 @@ interface AppContextType {
   getTotalRevenue: () => number;
   getTotalCosts: () => number;
   getTotalProfit: () => number;
+  getClientRevenue: (clientId: string) => number;
   getClientProfit: (clientId: string) => number;
   getClientMonthlyData: (clientId: string, year?: number) => MonthlyClientData[];
   getAnnualReport: (year: number) => AnnualReport;
@@ -392,6 +393,12 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     return getTotalRevenue() - getTotalCosts();
   };
 
+  const getClientRevenue = (clientId: string) => {
+    return invoices
+      .filter(inv => inv.clientId === clientId && inv.status === 'paid')
+      .reduce((sum, inv) => sum + inv.amountHT, 0);
+  };
+
   const getClientProfit = (clientId: string) => {
     const clientInvoices = invoices.filter(inv => inv.clientId === clientId && inv.status === 'paid');
     const clientCosts = costs.filter(cost => cost.clientId === clientId);
@@ -546,6 +553,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     getTotalRevenue,
     getTotalCosts,
     getTotalProfit,
+    getClientRevenue,
     getClientProfit,
     getClientMonthlyData,
     getAnnualReport,


### PR DESCRIPTION
## Summary
- add helper `getClientRevenue` to AppContext
- show calculated revenue for clients in ClientsManager and dashboard list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bf70f230832d990fb05187418247