### PR TITLE
Add monthly invoices chart

### DIFF
--- a/src/components/Invoices/InvoicesManager.tsx
+++ b/src/components/Invoices/InvoicesManager.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Plus, Search, Receipt, Clock, CheckCircle, AlertCircle, Download, Eye } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
 import InvoiceForm from './InvoiceForm';
+import InvoicesMonthlyChart from './InvoicesMonthlyChart';
 import { Invoice } from '../../types';
 
 const InvoicesManager: React.FC = () => {
@@ -136,6 +137,14 @@ const InvoicesManager: React.FC = () => {
             À déclarer
           </p>
         </div>
+      </div>
+
+      {/* Monthly Chart */}
+      <div className="bg-white rounded-xl shadow-sm p-6 mb-8">
+        <h2 className="text-xl font-semibold text-gray-900 mb-4">
+          Factures par Mois
+        </h2>
+        <InvoicesMonthlyChart />
       </div>
 
       {/* Filters */}

--- a/src/components/Invoices/InvoicesMonthlyChart.tsx
+++ b/src/components/Invoices/InvoicesMonthlyChart.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import { format, subMonths } from 'date-fns';
+import { useAppContext } from '../../context/AppContext';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+const InvoicesMonthlyChart: React.FC = () => {
+  const { invoices } = useAppContext();
+
+  const months = Array.from({ length: 12 }, (_, i) => {
+    const date = subMonths(new Date(), 11 - i);
+    return format(date, 'MMM yyyy');
+  });
+
+  const monthTotals = months.map(month =>
+    invoices
+      .filter(inv => format(inv.issueDate, 'MMM yyyy') === month)
+      .reduce((sum, inv) => sum + inv.amountHT, 0)
+  );
+
+  const data = {
+    labels: months,
+    datasets: [
+      {
+        label: 'Montant HT',
+        data: monthTotals,
+        backgroundColor: 'rgba(59, 130, 246, 0.8)',
+        borderColor: '#3B82F6',
+        borderWidth: 2,
+        borderRadius: 6,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        position: 'top' as const,
+        labels: {
+          usePointStyle: true,
+          padding: 20,
+          font: {
+            size: 12,
+            weight: '500',
+          },
+        },
+      },
+      tooltip: {
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        titleColor: '#ffffff',
+        bodyColor: '#ffffff',
+        borderColor: '#e5e7eb',
+        borderWidth: 1,
+        cornerRadius: 8,
+        displayColors: true,
+        callbacks: {
+          label: function (context: any) {
+            const value = context.parsed.y;
+            return `Montant: ${value.toLocaleString('fr-FR')} €`;
+          },
+        },
+      },
+    },
+    scales: {
+      x: {
+        grid: {
+          display: false,
+        },
+        ticks: {
+          color: '#6B7280',
+          font: {
+            size: 11,
+          },
+        },
+      },
+      y: {
+        grid: {
+          color: 'rgba(107, 114, 128, 0.1)',
+        },
+        ticks: {
+          color: '#6B7280',
+          font: {
+            size: 11,
+          },
+          callback: function (value: any) {
+            return value.toLocaleString('fr-FR') + ' €';
+          },
+        },
+      },
+    },
+  };
+
+  return (
+    <div className="h-80">
+      <Bar data={data} options={options} />
+    </div>
+  );
+};
+
+export default InvoicesMonthlyChart;


### PR DESCRIPTION
## Summary
- visualize invoice totals by month
- show the chart in invoice management

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c286ca94832d984dd84587e02174