### PR TITLE
Start charts from 2025

### DIFF
--- a/src/components/Invoices/InvoicesMonthlyChart.tsx
+++ b/src/components/Invoices/InvoicesMonthlyChart.tsx
@@ -17,8 +17,9 @@ ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
 const InvoicesMonthlyChart: React.FC = () => {
   const { invoices } = useAppContext();
 
+  // Show invoice data for each month of the year 2025
   const months = Array.from({ length: 12 }, (_, i) => {
-    const date = subMonths(new Date(), 11 - i);
+    const date = new Date(2025, i, 1);
     return format(date, 'MMM yyyy');
   });
 

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -354,8 +354,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
 
   // Analytics
   const getMonthlyData = (): MonthlyData[] => {
+    // Always display data starting from January 2025
     const months = Array.from({ length: 12 }, (_, i) => {
-      const date = subMonths(new Date(), 11 - i);
+      const date = new Date(2025, i, 1);
       return format(date, 'MMM yyyy');
     });
 


### PR DESCRIPTION
## Summary
- show monthly data from January 2025 in the app context
- update invoice monthly chart to start from January 2025

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c5cb6190832dadadc0995e3f6b1b