### PR TITLE
Add revenue share percentage for clients

### DIFF
--- a/src/components/Reports/AnnualReport.tsx
+++ b/src/components/Reports/AnnualReport.tsx
@@ -77,7 +77,7 @@ const AnnualReport: React.FC = () => {
 
   // Client distribution chart
   const clientChartData = {
-    labels: report.clientsData.map(c => c.clientName),
+    labels: report.clientsData.map(c => `${c.clientName} (${c.revenueShare.toFixed(1)}%)`),
     datasets: [
       {
         label: 'Revenus par client',
@@ -348,6 +348,9 @@ const AnnualReport: React.FC = () => {
                   Marge
                 </th>
                 <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Part CA
+                </th>
+                <th className="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                   Factures
                 </th>
               </tr>
@@ -377,10 +380,15 @@ const AnnualReport: React.FC = () => {
                   </td>
                   <td className="px-6 py-4">
                     <div className={`text-sm font-semibold ${
-                      client.margin >= 20 ? 'text-green-600' : 
+                      client.margin >= 20 ? 'text-green-600' :
                       client.margin >= 10 ? 'text-yellow-600' : 'text-red-600'
                     }`}>
                       {client.margin.toFixed(1)}%
+                    </div>
+                  </td>
+                  <td className="px-6 py-4">
+                    <div className="text-sm font-semibold text-gray-900">
+                      {client.revenueShare.toFixed(1)}%
                     </div>
                   </td>
                   <td className="px-6 py-4">

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -481,11 +481,12 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     const clientsData = clients.map(client => {
       const clientInvoices = yearInvoices.filter(inv => inv.clientId === client.id);
       const clientCosts = yearCosts.filter(cost => cost.clientId === client.id);
-      
+
       const revenue = clientInvoices.reduce((sum, inv) => sum + inv.amountHT, 0);
       const costs = clientCosts.reduce((sum, cost) => sum + cost.amount, 0);
       const profit = revenue - costs;
       const margin = revenue > 0 ? (profit / revenue) * 100 : 0;
+      const revenueShare = totalRevenue > 0 ? (revenue / totalRevenue) * 100 : 0;
 
       return {
         clientId: client.id,
@@ -494,6 +495,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
         costs,
         profit,
         margin,
+        revenueShare,
         invoicesCount: clientInvoices.length
       };
     });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -78,5 +78,7 @@ export interface ClientAnnualData {
   costs: number;
   profit: number;
   margin: number;
+  /** Part du chiffre d'affaires total sur l'année (en %) */
+  revenueShare: number;
   invoicesCount: number;
 }


### PR DESCRIPTION
## Summary
- extend `ClientAnnualData` with `revenueShare`
- compute each client's share of the total revenue
- display the percentage in the client chart legend and table

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e58f591c832d81589cb317a36de6