### PR TITLE
Add manual sync and settings modal

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -70,6 +70,14 @@ app.use('/clients', createRouter('clients'));
 app.use('/invoices', createRouter('invoices'));
 app.use('/costs', createRouter('costs'));
 
+// Endpoint to replace the entire dataset (used for manual sync)
+app.post('/sync', (req, res) => {
+  const { clients = [], invoices = [], costs = [] } = req.body || {};
+  const data = { clients, invoices, costs };
+  writeData(data);
+  res.sendStatus(204);
+});
+
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,10 +8,12 @@ import InvoicesManager from './components/Invoices/InvoicesManager';
 import CostsManager from './components/Costs/CostsManager';
 import ClientAnalytics from './components/Analytics/ClientAnalytics';
 import AnnualReport from './components/Reports/AnnualReport';
+import SettingsModal from './components/Settings/SettingsModal';
 
 function App() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [activeView, setActiveView] = useState('dashboard');
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
     const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
     if (stored) return stored;
@@ -54,6 +56,7 @@ function App() {
           onThemeToggle={() => setTheme(theme === 'light' ? 'dark' : 'light')}
           activeView={activeView}
           onViewChange={setActiveView}
+          onSettingsOpen={() => setSettingsOpen(true)}
         />
 
         <Sidebar
@@ -66,6 +69,7 @@ function App() {
         <main className="mx-auto max-w-7xl p-6">
           {renderActiveView()}
         </main>
+        <SettingsModal open={settingsOpen} onClose={() => setSettingsOpen(false)} />
       </div>
     </AppProvider>
   );

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -8,9 +8,10 @@ interface HeaderProps {
   onThemeToggle: () => void;
   activeView: string;
   onViewChange: (view: string) => void;
+  onSettingsOpen: () => void;
 }
 
-const Header: React.FC<HeaderProps> = ({ onMenuToggle, theme, onThemeToggle, activeView, onViewChange }) => {
+const Header: React.FC<HeaderProps> = ({ onMenuToggle, theme, onThemeToggle, activeView, onViewChange, onSettingsOpen }) => {
   const { currentUser, setCurrentUser } = useAppContext();
 
   const handleRoleToggle = () => {
@@ -85,7 +86,7 @@ const Header: React.FC<HeaderProps> = ({ onMenuToggle, theme, onThemeToggle, act
             </span>
           </div>
 
-          <button className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+          <button onClick={onSettingsOpen} className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
             <Settings className="h-5 w-5 text-gray-600 dark:text-gray-300" />
           </button>
         </div>

--- a/src/components/Settings/SettingsModal.tsx
+++ b/src/components/Settings/SettingsModal.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { X, Save } from 'lucide-react';
+import { useAppContext } from '../../context/AppContext';
+
+interface SettingsModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SettingsModal: React.FC<SettingsModalProps> = ({ open, onClose }) => {
+  const { syncData } = useAppContext();
+
+  if (!open) return null;
+
+  const handleSync = async () => {
+    await syncData();
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-lg w-full max-w-md">
+        <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">Paramètres</h2>
+          <button onClick={onClose} className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg transition-colors">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="p-6 space-y-4">
+          <button onClick={handleSync} className="flex items-center space-x-2 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors">
+            <Save className="h-4 w-4" />
+            <span>Sauvegarder vers le serveur</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SettingsModal;

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -12,7 +12,7 @@ import {
 } from '../types';
 import { format, subMonths, addMonths, getYear } from 'date-fns';
 
-const API_URL = 'http://localhost:3000';
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 const LOCAL_STORAGE_KEY = 'maintup-data';
 
 interface AppContextType {
@@ -37,6 +37,9 @@ interface AppContextType {
   addCost: (cost: Omit<Cost, 'id'>) => void;
   updateCost: (id: string, cost: Partial<Cost>) => void;
   deleteCost: (id: string) => void;
+
+  // Manual sync
+  syncData: () => Promise<void>;
   
   // Analytics
   getMonthlyData: () => MonthlyData[];
@@ -552,6 +555,18 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     return pdfUrl;
   };
 
+  const syncData = async (): Promise<void> => {
+    try {
+      await fetch(`${API_URL}/sync`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clients, invoices, costs })
+      });
+    } catch (e) {
+      console.error('Sync failed', e);
+    }
+  };
+
   const value: AppContextType = {
     currentUser,
     setCurrentUser,
@@ -575,7 +590,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     getClientProfit,
     getClientMonthlyData,
     getAnnualReport,
-    exportToPDF
+    exportToPDF,
+    syncData
   };
 
   return (


### PR DESCRIPTION
## Summary
- add `/sync` endpoint on the backend to upload data
- support `VITE_API_URL` and introduce `syncData` helper
- create a settings modal with a save button
- open settings modal from the header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a56ffb0cc832d995b6393dae87312