### PR TITLE
Configure Vercel alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ La barre latérale donne accès aux différentes pages :
 - Mode sécurisé : l'application démarre en mode "Visualisation". Cliquez sur le
   bouton "Mode" pour passer administrateur et saisissez le mot de passe
   **THABARY**.
+## Déploiement sur Vercel
+
+Ce projet inclut un fichier `vercel.json` qui associe automatiquement l'application au domaine https://maint-up.vercel.app lors du déploiement.
+
 
 ## Licence
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "alias": "maint-up.vercel.app"
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` to set the deployment alias
- document Vercel alias in the README

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b33936788832d83224c15c8d766b0