### PR TITLE
Restrict API access to main domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ npm run server
 ```
 
 L'application communiquera alors avec ce backend pour sauvegarder clients, factures
-et coûts. Si le serveur n'est pas disponible, l'application fonctionne quand même
-grâce à un stockage dans le `localStorage` du navigateur. Vos données seront ainsi
+et coûts. Par mesure de sécurité, seules les requêtes provenant du domaine
+`https://maint-up.vercel.app` sont acceptées.
+Si le serveur n'est pas disponible, l'application fonctionne quand même grâce
+à un stockage dans le `localStorage` du navigateur. Vos données seront ainsi
 conservées localement et synchronisées avec le backend dès qu'il sera de nouveau
 accessible.
 

--- a/server/index.js
+++ b/server/index.js
@@ -6,7 +6,8 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 const DATA_FILE = new URL('./data.json', import.meta.url);
 
-app.use(cors());
+const ALLOWED_ORIGIN = 'https://maint-up.vercel.app';
+app.use(cors({ origin: ALLOWED_ORIGIN }));
 app.use(express.json());
 
 function readData() {


### PR DESCRIPTION
## Summary
- restrict CORS to `https://maint-up.vercel.app`
- document allowed origin in the backend section

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bc5ef46b0832d9998df4ab774aa5f