### PR TITLE
Add API token protection for backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+VITE_API_URL=http://localhost:3000
+# Token utilise pour les requetes d'ecriture
+VITE_API_TOKEN=your_api_token_here
+API_TOKEN=your_api_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ Thumbs.db
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.env
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ La barre latérale donne accès aux différentes pages :
 
 Ce projet inclut un fichier `vercel.json` qui associe automatiquement l'application au domaine https://maint-up.vercel.app lors du déploiement.
 
+## Sécurisation de l'API
+
+Le serveur Express peut être protégé par un jeton d'API. Définissez la variable
+d'environnement `API_TOKEN` lors du démarrage du serveur pour activer cette
+protection. Toutes les requêtes d'écriture (POST, PUT, DELETE et `/sync`) doivent
+alors fournir l'en-tête `Authorization: Bearer <token>`.
+
+Pour utiliser cette authentification côté client, créez un fichier `.env` avec
+la variable `VITE_API_TOKEN` contenant le même jeton. Si cette variable n'est
+pas définie, l'application fonctionne en lecture seule.
+
 
 ## Licence
 

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -20,6 +20,8 @@ import {
 import { format, subMonths, addMonths, getYear } from 'date-fns';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const API_TOKEN = import.meta.env.VITE_API_TOKEN;
+const AUTH_HEADER = API_TOKEN ? { Authorization: `Bearer ${API_TOKEN}` } : {};
 const LOCAL_STORAGE_KEY = 'maintup-data';
 
 interface AppContextType {
@@ -178,7 +180,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     try {
       const res = await fetch(`${API_URL}/clients`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
         body: JSON.stringify(clientData)
       });
       if (!res.ok) throw new Error('api');
@@ -210,7 +212,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     try {
       const res = await fetch(`${API_URL}/clients/${id}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
         body: JSON.stringify(updates)
       });
       if (!res.ok) throw new Error('api');
@@ -234,7 +236,10 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
 
   const deleteClient = async (id: string) => {
     try {
-      await fetch(`${API_URL}/clients/${id}`, { method: 'DELETE' });
+      await fetch(`${API_URL}/clients/${id}`, {
+        method: 'DELETE',
+        headers: AUTH_HEADER
+      });
     } catch (e) {
       // offline, just update local data
       setUnsynced(true);
@@ -261,7 +266,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     try {
       const res = await fetch(`${API_URL}/invoices`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
         body: JSON.stringify(invoiceData)
       });
       if (!res.ok) throw new Error('api');
@@ -294,7 +299,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     try {
       const res = await fetch(`${API_URL}/invoices/${id}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
         body: JSON.stringify(updates)
       });
       if (!res.ok) throw new Error('api');
@@ -318,7 +323,10 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
 
   const deleteInvoice = async (id: string) => {
     try {
-      await fetch(`${API_URL}/invoices/${id}`, { method: 'DELETE' });
+      await fetch(`${API_URL}/invoices/${id}`, {
+        method: 'DELETE',
+        headers: AUTH_HEADER
+      });
     } catch (e) {
       // offline
       setUnsynced(true);
@@ -340,7 +348,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     try {
       const res = await fetch(`${API_URL}/costs`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
         body: JSON.stringify(costData)
       });
       if (!res.ok) throw new Error('api');
@@ -366,7 +374,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     try {
       const res = await fetch(`${API_URL}/costs/${id}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
         body: JSON.stringify(updates)
       });
       if (!res.ok) throw new Error('api');
@@ -389,7 +397,10 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
 
   const deleteCost = async (id: string) => {
     try {
-      await fetch(`${API_URL}/costs/${id}`, { method: 'DELETE' });
+      await fetch(`${API_URL}/costs/${id}`, {
+        method: 'DELETE',
+        headers: AUTH_HEADER
+      });
     } catch (e) {
       // offline
       setUnsynced(true);
@@ -610,7 +621,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       try {
         await fetch(`${API_URL}/sync`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: { 'Content-Type': 'application/json', ...AUTH_HEADER },
           body: JSON.stringify({ clients: c, invoices: i, costs: co })
         });
         persist(c, i, co, false);


### PR DESCRIPTION
## Summary
- secure express server with optional API token
- pass token from frontend when defined
- document API token usage
- provide `.env.example` and ignore `.env`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ff75e7e48832d8bbf03e6e9306d79