### PR TITLE
Integrate office costs with global expenses

### DIFF
--- a/src/components/Costs/CostForm.tsx
+++ b/src/components/Costs/CostForm.tsx
@@ -15,7 +15,7 @@ const CostForm: React.FC<CostFormProps> = ({ cost, onClose }) => {
     invoiceId: cost?.invoiceId || '',
     description: cost?.description || '',
     amount: cost?.amount || 0,
-    category: cost?.category || 'materials' as 'salaries' | 'charges' | 'subcontracting' | 'materials' | 'transport' | 'housing' | 'other',
+    category: cost?.category || 'materials' as 'office' | 'salaries' | 'charges' | 'subcontracting' | 'materials' | 'transport' | 'housing' | 'other',
     date: cost?.date ? cost.date.toISOString().split('T')[0] : new Date().toISOString().split('T')[0]
   });
 
@@ -47,6 +47,7 @@ const CostForm: React.FC<CostFormProps> = ({ cost, onClose }) => {
     { id: 'charges', label: '📊 Charges sociales', color: 'text-purple-600' },
     { id: 'subcontracting', label: '🤝 Sous-traitance', color: 'text-green-600' },
     { id: 'materials', label: '🔧 Matériaux', color: 'text-orange-600' },
+    { id: 'office', label: '🏢 Bureau', color: 'text-indigo-600' },
     { id: 'transport', label: '🚛 Transport', color: 'text-yellow-600' },
     { id: 'housing', label: '🏠 Logements', color: 'text-teal-600' },
     { id: 'other', label: '📋 Autre', color: 'text-gray-600' },

--- a/src/components/Costs/CostsManager.tsx
+++ b/src/components/Costs/CostsManager.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { format } from 'date-fns';
-import { Plus, Search, DollarSign, Users, FileText, Truck, Wrench, BarChart3, Home } from 'lucide-react';
+import { Plus, Search, DollarSign, Users, FileText, Truck, Wrench, BarChart3, Home, Building2 } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
 import CostForm from './CostForm';
 import { Cost } from '../../types';
@@ -18,6 +18,7 @@ const CostsManager: React.FC = () => {
     { id: 'charges', label: '📊 Charges sociales', icon: BarChart3, color: 'text-purple-600', bg: 'bg-purple-50' },
     { id: 'subcontracting', label: '🤝 Sous-traitance', icon: Users, color: 'text-green-600', bg: 'bg-green-50' },
     { id: 'materials', label: '🔧 Matériaux', icon: Wrench, color: 'text-orange-600', bg: 'bg-orange-50' },
+    { id: 'office', label: '🏢 Bureau', icon: Building2, color: 'text-indigo-600', bg: 'bg-indigo-50' },
     { id: 'transport', label: '🚛 Transport', icon: Truck, color: 'text-yellow-600', bg: 'bg-yellow-50' },
     { id: 'housing', label: '🏠 Logements', icon: Home, color: 'text-teal-600', bg: 'bg-teal-50' },
     { id: 'other', label: '📋 Autre', icon: FileText, color: 'text-gray-600', bg: 'bg-gray-50' },
@@ -35,7 +36,7 @@ const CostsManager: React.FC = () => {
     return matchesSearch && matchesCategory && matchesClient;
   });
 
-  const fixedCategories = ['salaries', 'charges', 'housing'];
+  const fixedCategories = ['salaries', 'charges', 'housing', 'office'];
   const fixedCosts = filteredCosts.filter(cost => fixedCategories.includes(cost.category));
   const variableCosts = filteredCosts.filter(cost => !fixedCategories.includes(cost.category));
 
@@ -53,7 +54,7 @@ const CostsManager: React.FC = () => {
   };
 
   const getCategoryInfo = (categoryId: string) => {
-    return categories.find(cat => cat.id === categoryId) || categories[5];
+    return categories.find(cat => cat.id === categoryId) || categories[categories.length - 1];
   };
 
   const getInvoiceInfo = (invoiceId?: string) => {

--- a/src/components/Costs/OfficeCosts.tsx
+++ b/src/components/Costs/OfficeCosts.tsx
@@ -1,9 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import {
-  Plus,
-  Trash,
-  Home
-} from 'lucide-react';
+import React, { useState } from 'react';
+import { Plus, Trash } from 'lucide-react';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -13,214 +9,53 @@ import {
   Legend
 } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
-import { format, parseISO, startOfMonth, addMonths } from 'date-fns';
+import { format } from 'date-fns';
+import { useAppContext } from '../../context/AppContext';
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
 
-// Types
-export type ExpenseType = 'fixed' | 'variable' | 'salary';
-
-interface OfficeExpense {
-  id: string;
-  date: string; // YYYY-MM-DD
-  type: ExpenseType;
-  category: string;
-  description: string;
-  amount: number;
-}
-
-const fixedCategories = [
-  'google',
-  'expert comptable',
-  'chat gpt',
-  'logiciel',
-  'téléphone',
-  'kandbazz',
-  'bureau',
-  'assurance maladie',
-  'frais bancaire',
-  'linkedin',
-  'voiture',
-  'assurance voiture',
-  'assurance société',
-  'mutuelle',
-  'retraite',
-  'autre'
-];
-
-const variableCategories = [
-  'essence',
-  'péage',
-  'formation',
-  'outils',
-  'hotel',
-  'vêtements',
-  'autre'
-];
-
-const salaryCategories = ['salaire', 'charge', 'autre'];
-
-const STORAGE_KEY = 'office-expenses';
+const OFFICE_CLIENT_ID = 'office';
+const OFFICE_CLIENT_NAME = 'Charges Bureau';
 
 const OfficeCosts: React.FC = () => {
-  const [expenses, setExpenses] = useState<OfficeExpense[]>(() => {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved) {
-      try {
-        return JSON.parse(saved) as OfficeExpense[];
-      } catch {
-        return [];
-      }
-    }
-    return [];
+  const { costs, addCost, deleteCost } = useAppContext();
+  const officeCosts = costs.filter(c => c.category === 'office');
+
+  const [form, setForm] = useState({
+    date: new Date().toISOString().split('T')[0],
+    description: '',
+    amount: 0
   });
 
-  useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(expenses));
-  }, [expenses]);
-
-  const addExpense = (type: ExpenseType) => {
-    const newExpense: OfficeExpense = {
-      id: Date.now().toString(),
-      date: '2025-01-01',
-      type,
-      category:
-        type === 'fixed'
-          ? fixedCategories[0]
-          : type === 'variable'
-          ? variableCategories[0]
-          : salaryCategories[0],
-      description: '',
-      amount: 0
-    };
-    setExpenses([...expenses, newExpense]);
-  };
-
-  const updateExpense = (id: string, partial: Partial<OfficeExpense>) => {
-    setExpenses(expenses.map(e => (e.id === id ? { ...e, ...partial } : e)));
-  };
-
-  const deleteExpense = (id: string) => {
-    setExpenses(expenses.filter(e => e.id !== id));
-  };
-
-  const renderTable = (type: ExpenseType, categories: string[], title: string) => {
-    const filtered = expenses.filter(e => e.type === type);
-    return (
-      <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
-          <button
-            onClick={() => addExpense(type)}
-            className="flex items-center space-x-2 bg-primary-600 text-white px-3 py-2 rounded-lg hover:bg-primary-700 transition-colors"
-          >
-            <Plus className="h-4 w-4" />
-            <span>Ajouter</span>
-          </button>
-        </div>
-        <div className="overflow-x-auto">
-          <table className="w-full">
-            <thead className="bg-gray-50 border-b border-gray-200">
-              <tr>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Date
-                </th>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Catégorie
-                </th>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Description
-                </th>
-                <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                  Montant
-                </th>
-                <th className="px-4 py-2" />
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {filtered.map(expense => (
-                <tr key={expense.id} className="hover:bg-gray-50">
-                  <td className="px-4 py-2">
-                    <input
-                      type="date"
-                      value={expense.date}
-                      onChange={e => updateExpense(expense.id, { date: e.target.value })}
-                      className="px-2 py-1 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                    />
-                  </td>
-                  <td className="px-4 py-2">
-                    <select
-                      value={expense.category}
-                      onChange={e => updateExpense(expense.id, { category: e.target.value })}
-                      className="px-2 py-1 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                    >
-                      {categories.map(cat => (
-                        <option key={cat} value={cat}>{cat}</option>
-                      ))}
-                    </select>
-                  </td>
-                  <td className="px-4 py-2">
-                    <input
-                      type="text"
-                      value={expense.description}
-                      onChange={e => updateExpense(expense.id, { description: e.target.value })}
-                      className="w-full px-2 py-1 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                    />
-                  </td>
-                  <td className="px-4 py-2">
-                    <input
-                      type="number"
-                      min="0"
-                      step="0.01"
-                      value={expense.amount}
-                      onChange={e => updateExpense(expense.id, { amount: parseFloat(e.target.value) || 0 })}
-                      className="w-32 px-2 py-1 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                    />
-                  </td>
-                  <td className="px-4 py-2 text-right">
-                    <button onClick={() => deleteExpense(expense.id)} className="text-red-600 hover:text-red-800">
-                      <Trash className="h-4 w-4" />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    );
-  };
-
-  // Prepare chart data
-  const months = Array.from({ length: 12 }, (_, i) => format(addMonths(new Date(2025, 0, 1), i), 'MMM yyyy'));
-
-  const totalByMonth = (type: ExpenseType) => {
-    return months.map((_, idx) => {
-      const start = startOfMonth(addMonths(new Date(2025, 0, 1), idx));
-      const end = startOfMonth(addMonths(new Date(2025, 0, 1), idx + 1));
-      return expenses
-        .filter(e => e.type === type && parseISO(e.date) >= start && parseISO(e.date) < end)
-        .reduce((sum, e) => sum + e.amount, 0);
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.description || form.amount <= 0) return;
+    addCost({
+      clientId: OFFICE_CLIENT_ID,
+      clientName: OFFICE_CLIENT_NAME,
+      invoiceId: '',
+      description: form.description,
+      amount: form.amount,
+      category: 'office',
+      date: new Date(form.date)
     });
+    setForm({ date: new Date().toISOString().split('T')[0], description: '', amount: 0 });
   };
+
+  const months = Array.from({ length: 12 }, (_, i) => format(new Date(2025, i, 1), 'MMM yyyy'));
+  const totals = months.map(m =>
+    officeCosts
+      .filter(c => format(c.date, 'MMM yyyy') === m)
+      .reduce((sum, c) => sum + c.amount, 0)
+  );
 
   const chartData = {
     labels: months,
     datasets: [
       {
-        label: 'Frais fixes',
-        data: totalByMonth('fixed'),
-        backgroundColor: '#3B82F6'
-      },
-      {
-        label: 'Frais variables',
-        data: totalByMonth('variable'),
-        backgroundColor: '#EF4444'
-      },
-      {
-        label: 'Salaires',
-        data: totalByMonth('salary'),
-        backgroundColor: '#10B981'
+        label: 'Charges Bureau',
+        data: totals,
+        backgroundColor: '#6366F1'
       }
     ]
   };
@@ -231,19 +66,12 @@ const OfficeCosts: React.FC = () => {
     plugins: {
       legend: {
         position: 'top' as const,
-        labels: {
-          usePointStyle: true,
-          padding: 20,
-          font: {
-            size: 12,
-            weight: '500'
-          }
-        }
+        labels: { usePointStyle: true, padding: 20, font: { size: 12, weight: '500' } }
       },
       tooltip: {
         callbacks: {
           label: function(context: any) {
-            return `${context.dataset.label}: ${context.parsed.y.toLocaleString('fr-FR')} €`;
+            return `${context.parsed.y.toLocaleString('fr-FR')} €`;
           }
         }
       }
@@ -262,11 +90,74 @@ const OfficeCosts: React.FC = () => {
 
   return (
     <div className="space-y-8">
-      {renderTable('fixed', fixedCategories, 'Frais fixes')}
-      {renderTable('variable', variableCategories, 'Frais variables')}
-      {renderTable('salary', salaryCategories, 'Salaires')}
       <div className="bg-white rounded-xl shadow-sm p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Évolution mensuelle</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Ajouter une dépense de bureau</h2>
+        <form onSubmit={handleSubmit} className="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Date</label>
+            <input
+              type="date"
+              value={form.date}
+              onChange={e => setForm({ ...form, date: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+            <input
+              type="text"
+              value={form.description}
+              onChange={e => setForm({ ...form, description: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              placeholder="Loyer, matériel..."
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Montant (€)</label>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={form.amount}
+              onChange={e => setForm({ ...form, amount: parseFloat(e.target.value) || 0 })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            />
+          </div>
+          <button type="submit" className="flex items-center justify-center bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors">
+            <Plus className="h-4 w-4 mr-2" /> Ajouter
+          </button>
+        </form>
+      </div>
+
+      <div className="bg-white rounded-xl shadow-sm overflow-x-auto">
+        <table className="w-full">
+          <thead className="bg-gray-50 border-b border-gray-200">
+            <tr>
+              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
+              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Montant</th>
+              <th className="px-4 py-2" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {officeCosts.map(cost => (
+              <tr key={cost.id} className="hover:bg-gray-50">
+                <td className="px-4 py-2 text-sm text-gray-900">{cost.date.toLocaleDateString('fr-FR')}</td>
+                <td className="px-4 py-2 text-sm text-gray-900">{cost.description}</td>
+                <td className="px-4 py-2 text-sm font-semibold text-red-600">{cost.amount.toLocaleString('fr-FR')} €</td>
+                <td className="px-4 py-2 text-right">
+                  <button onClick={() => deleteCost(cost.id)} className="text-red-600 hover:text-red-800">
+                    <Trash className="h-4 w-4" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="bg-white rounded-xl shadow-sm p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Évolution mensuelle 2025</h2>
         <div className="h-80">
           <Bar data={chartData} options={chartOptions} />
         </div>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -560,6 +560,22 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       };
     });
 
+    // Add office costs as a separate entry if any
+    const officeCosts = yearCosts.filter(cost => cost.category === 'office');
+    if (officeCosts.length > 0) {
+      const officeTotal = officeCosts.reduce((sum, c) => sum + c.amount, 0);
+      clientsData.push({
+        clientId: 'office',
+        clientName: 'Charges Bureau',
+        revenue: 0,
+        costs: officeTotal,
+        profit: -officeTotal,
+        margin: 0,
+        revenueShare: 0,
+        invoicesCount: 0
+      });
+    }
+
     const monthlyBreakdown = Array.from({ length: 12 }, (_, i) => {
       const month = format(new Date(year, i, 1), 'MMM yyyy');
       

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,7 +32,7 @@ export interface Cost {
   invoiceId?: string;
   description: string;
   amount: number;
-  category: 'salaries' | 'charges' | 'subcontracting' | 'materials' | 'transport' | 'housing' | 'other';
+  category: 'office' | 'salaries' | 'charges' | 'subcontracting' | 'materials' | 'transport' | 'housing' | 'other';
   date: Date;
 }
 


### PR DESCRIPTION
## Summary
- support new `office` cost category
- allow selecting "Bureau" category in cost form
- show office category inside cost management view
- include office costs in annual report figures
- replace local office expenses with context-based version

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68591174c4f4832d8c6e1f01e64fc7f5