### PR TITLE
Add detailed office cost tracking

### DIFF
--- a/src/components/Costs/OfficeCosts.tsx
+++ b/src/components/Costs/OfficeCosts.tsx
@@ -5,112 +5,170 @@ import {
   CategoryScale,
   LinearScale,
   BarElement,
+  ArcElement,
   Tooltip,
   Legend
 } from 'chart.js';
-import { Bar } from 'react-chartjs-2';
+import { Bar, Pie } from 'react-chartjs-2';
 import { format } from 'date-fns';
 import { useAppContext } from '../../context/AppContext';
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Tooltip, Legend);
 
 const OFFICE_CLIENT_ID = 'office';
 const OFFICE_CLIENT_NAME = 'Charges Bureau';
+
+interface FormState {
+  date: string;
+  category: string;
+  amount: number;
+}
+
+const fixedCategories = [
+  'Google',
+  'Expert comptable',
+  'ChatGPT',
+  'Logiciel',
+  'Téléphone',
+  'Kandbazz',
+  'Bureau',
+  'Assurance maladie',
+  'Frais bancaires',
+  'LinkedIn',
+  'Voiture',
+  'Assurance voiture',
+  'Assurance société',
+  'Mutuelle',
+  'Retraite',
+  'Autre'
+];
+
+const variableCategories = [
+  'Essence',
+  'Péage',
+  'Formation',
+  'Outils',
+  'Hôtel',
+  'Vêtements',
+  'Autre'
+];
+
+const payrollCategories = ['Salaire', 'Charges', 'Autre'];
 
 const OfficeCosts: React.FC = () => {
   const { costs, addCost, deleteCost } = useAppContext();
   const officeCosts = costs.filter(c => c.category === 'office');
 
-  const [form, setForm] = useState({
+  const fixedCosts = officeCosts.filter(c => c.officeType === 'fixed');
+  const variableCosts = officeCosts.filter(c => c.officeType === 'variable');
+  const payrollCosts = officeCosts.filter(c => c.officeType === 'payroll');
+
+  const [fixedForm, setFixedForm] = useState<FormState>({
     date: new Date().toISOString().split('T')[0],
-    description: '',
+    category: fixedCategories[0],
     amount: 0
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!form.description || form.amount <= 0) return;
+  const [variableForm, setVariableForm] = useState<FormState>({
+    date: new Date().toISOString().split('T')[0],
+    category: variableCategories[0],
+    amount: 0
+  });
+
+  const [payrollForm, setPayrollForm] = useState<FormState>({
+    date: new Date().toISOString().split('T')[0],
+    category: payrollCategories[0],
+    amount: 0
+  });
+
+  const handleSubmit = (type: 'fixed' | 'variable' | 'payroll', form: FormState) => {
+    if (form.amount <= 0) return;
     addCost({
       clientId: OFFICE_CLIENT_ID,
       clientName: OFFICE_CLIENT_NAME,
       invoiceId: '',
-      description: form.description,
+      description: form.category,
       amount: form.amount,
       category: 'office',
+      officeType: type,
+      officeCategory: form.category,
       date: new Date(form.date)
     });
-    setForm({ date: new Date().toISOString().split('T')[0], description: '', amount: 0 });
   };
 
   const months = Array.from({ length: 12 }, (_, i) => format(new Date(2025, i, 1), 'MMM yyyy'));
-  const totals = months.map(m =>
-    officeCosts
-      .filter(c => format(c.date, 'MMM yyyy') === m)
-      .reduce((sum, c) => sum + c.amount, 0)
-  );
 
-  const chartData = {
+  const computeTotals = (data: typeof officeCosts) =>
+    months.map(m =>
+      data
+        .filter(c => format(c.date, 'MMM yyyy') === m)
+        .reduce((sum, c) => sum + c.amount, 0)
+    );
+
+  const fixedTotals = computeTotals(fixedCosts);
+  const variableTotals = computeTotals(variableCosts);
+  const payrollTotals = computeTotals(payrollCosts);
+
+  const barData = {
     labels: months,
     datasets: [
+      { label: 'Frais fixes', data: fixedTotals, backgroundColor: '#6366F1' },
+      { label: 'Frais variables', data: variableTotals, backgroundColor: '#F59E0B' },
+      { label: 'Salaires & Charges', data: payrollTotals, backgroundColor: '#10B981' }
+    ]
+  };
+
+  const globalTotal = fixedCosts.reduce((s, c) => s + c.amount, 0) +
+    variableCosts.reduce((s, c) => s + c.amount, 0) +
+    payrollCosts.reduce((s, c) => s + c.amount, 0);
+
+  const pieData = {
+    labels: ['Frais fixes', 'Frais variables', 'Salaires & Charges'],
+    datasets: [
       {
-        label: 'Charges Bureau',
-        data: totals,
-        backgroundColor: '#6366F1'
+        data: [
+          fixedCosts.reduce((s, c) => s + c.amount, 0),
+          variableCosts.reduce((s, c) => s + c.amount, 0),
+          payrollCosts.reduce((s, c) => s + c.amount, 0)
+        ],
+        backgroundColor: ['#6366F1', '#F59E0B', '#10B981']
       }
     ]
   };
 
-  const chartOptions = {
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      legend: {
-        position: 'top' as const,
-        labels: { usePointStyle: true, padding: 20, font: { size: 12, weight: '500' } }
-      },
-      tooltip: {
-        callbacks: {
-          label: function(context: any) {
-            return `${context.parsed.y.toLocaleString('fr-FR')} €`;
-          }
-        }
-      }
-    },
-    scales: {
-      y: {
-        beginAtZero: true,
-        ticks: {
-          callback: function(value: any) {
-            return value.toLocaleString('fr-FR') + ' €';
-          }
-        }
-      }
-    }
-  };
-
   return (
     <div className="space-y-8">
+      {/* Fixed costs */}
       <div className="bg-white rounded-xl shadow-sm p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Ajouter une dépense de bureau</h2>
-        <form onSubmit={handleSubmit} className="grid grid-cols-1 md:grid-cols-4 gap-4 items-end">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Frais fixes</h2>
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            handleSubmit('fixed', fixedForm);
+            setFixedForm({ ...fixedForm, amount: 0 });
+          }}
+          className="grid grid-cols-1 md:grid-cols-4 gap-4 items-end"
+        >
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Date</label>
             <input
-              type="date"
-              value={form.date}
-              onChange={e => setForm({ ...form, date: e.target.value })}
+              type="month"
+              value={fixedForm.date}
+              onChange={e => setFixedForm({ ...fixedForm, date: e.target.value })}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
-            <input
-              type="text"
-              value={form.description}
-              onChange={e => setForm({ ...form, description: e.target.value })}
+            <label className="block text-sm font-medium text-gray-700 mb-1">Catégorie</label>
+            <select
+              value={fixedForm.category}
+              onChange={e => setFixedForm({ ...fixedForm, category: e.target.value })}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-              placeholder="Loyer, matériel..."
-            />
+            >
+              {fixedCategories.map(cat => (
+                <option key={cat} value={cat}>{cat}</option>
+              ))}
+            </select>
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Montant (€)</label>
@@ -118,8 +176,8 @@ const OfficeCosts: React.FC = () => {
               type="number"
               min="0"
               step="0.01"
-              value={form.amount}
-              onChange={e => setForm({ ...form, amount: parseFloat(e.target.value) || 0 })}
+              value={fixedForm.amount}
+              onChange={e => setFixedForm({ ...fixedForm, amount: parseFloat(e.target.value) || 0 })}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             />
           </div>
@@ -127,41 +185,210 @@ const OfficeCosts: React.FC = () => {
             <Plus className="h-4 w-4 mr-2" /> Ajouter
           </button>
         </form>
+
+        {fixedCosts.length > 0 && (
+          <div className="overflow-x-auto mt-4">
+            <table className="w-full">
+              <thead className="bg-gray-50 border-b border-gray-200">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Catégorie</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Montant</th>
+                  <th className="px-4 py-2" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {fixedCosts.map(cost => (
+                  <tr key={cost.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-2 text-sm text-gray-900">{format(cost.date, 'MM/yyyy')}</td>
+                    <td className="px-4 py-2 text-sm text-gray-900">{cost.officeCategory}</td>
+                    <td className="px-4 py-2 text-sm font-semibold text-red-600">{cost.amount.toLocaleString('fr-FR')} €</td>
+                    <td className="px-4 py-2 text-right">
+                      <button onClick={() => deleteCost(cost.id)} className="text-red-600 hover:text-red-800">
+                        <Trash className="h-4 w-4" />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
 
-      <div className="bg-white rounded-xl shadow-sm overflow-x-auto">
-        <table className="w-full">
-          <thead className="bg-gray-50 border-b border-gray-200">
-            <tr>
-              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
-              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-              <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Montant</th>
-              <th className="px-4 py-2" />
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-200">
-            {officeCosts.map(cost => (
-              <tr key={cost.id} className="hover:bg-gray-50">
-                <td className="px-4 py-2 text-sm text-gray-900">{cost.date.toLocaleDateString('fr-FR')}</td>
-                <td className="px-4 py-2 text-sm text-gray-900">{cost.description}</td>
-                <td className="px-4 py-2 text-sm font-semibold text-red-600">{cost.amount.toLocaleString('fr-FR')} €</td>
-                <td className="px-4 py-2 text-right">
-                  <button onClick={() => deleteCost(cost.id)} className="text-red-600 hover:text-red-800">
-                    <Trash className="h-4 w-4" />
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-
+      {/* Variable costs */}
       <div className="bg-white rounded-xl shadow-sm p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Évolution mensuelle 2025</h2>
-        <div className="h-80">
-          <Bar data={chartData} options={chartOptions} />
-        </div>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Frais variables</h2>
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            handleSubmit('variable', variableForm);
+            setVariableForm({ ...variableForm, amount: 0 });
+          }}
+          className="grid grid-cols-1 md:grid-cols-4 gap-4 items-end"
+        >
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Date</label>
+            <input
+              type="month"
+              value={variableForm.date}
+              onChange={e => setVariableForm({ ...variableForm, date: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Catégorie</label>
+            <select
+              value={variableForm.category}
+              onChange={e => setVariableForm({ ...variableForm, category: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            >
+              {variableCategories.map(cat => (
+                <option key={cat} value={cat}>{cat}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Montant (€)</label>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={variableForm.amount}
+              onChange={e => setVariableForm({ ...variableForm, amount: parseFloat(e.target.value) || 0 })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            />
+          </div>
+          <button type="submit" className="flex items-center justify-center bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors">
+            <Plus className="h-4 w-4 mr-2" /> Ajouter
+          </button>
+        </form>
+
+        {variableCosts.length > 0 && (
+          <div className="overflow-x-auto mt-4">
+            <table className="w-full">
+              <thead className="bg-gray-50 border-b border-gray-200">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Catégorie</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Montant</th>
+                  <th className="px-4 py-2" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {variableCosts.map(cost => (
+                  <tr key={cost.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-2 text-sm text-gray-900">{format(cost.date, 'MM/yyyy')}</td>
+                    <td className="px-4 py-2 text-sm text-gray-900">{cost.officeCategory}</td>
+                    <td className="px-4 py-2 text-sm font-semibold text-red-600">{cost.amount.toLocaleString('fr-FR')} €</td>
+                    <td className="px-4 py-2 text-right">
+                      <button onClick={() => deleteCost(cost.id)} className="text-red-600 hover:text-red-800">
+                        <Trash className="h-4 w-4" />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
+
+      {/* Payroll */}
+      <div className="bg-white rounded-xl shadow-sm p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Salaires & Charges</h2>
+        <form
+          onSubmit={e => {
+            e.preventDefault();
+            handleSubmit('payroll', payrollForm);
+            setPayrollForm({ ...payrollForm, amount: 0 });
+          }}
+          className="grid grid-cols-1 md:grid-cols-4 gap-4 items-end"
+        >
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Date</label>
+            <input
+              type="month"
+              value={payrollForm.date}
+              onChange={e => setPayrollForm({ ...payrollForm, date: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Catégorie</label>
+            <select
+              value={payrollForm.category}
+              onChange={e => setPayrollForm({ ...payrollForm, category: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            >
+              {payrollCategories.map(cat => (
+                <option key={cat} value={cat}>{cat}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Montant (€)</label>
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              value={payrollForm.amount}
+              onChange={e => setPayrollForm({ ...payrollForm, amount: parseFloat(e.target.value) || 0 })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            />
+          </div>
+          <button type="submit" className="flex items-center justify-center bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors">
+            <Plus className="h-4 w-4 mr-2" /> Ajouter
+          </button>
+        </form>
+
+        {payrollCosts.length > 0 && (
+          <div className="overflow-x-auto mt-4">
+            <table className="w-full">
+              <thead className="bg-gray-50 border-b border-gray-200">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Date</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Catégorie</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Montant</th>
+                  <th className="px-4 py-2" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {payrollCosts.map(cost => (
+                  <tr key={cost.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-2 text-sm text-gray-900">{format(cost.date, 'MM/yyyy')}</td>
+                    <td className="px-4 py-2 text-sm text-gray-900">{cost.officeCategory}</td>
+                    <td className="px-4 py-2 text-sm font-semibold text-red-600">{cost.amount.toLocaleString('fr-FR')} €</td>
+                    <td className="px-4 py-2 text-right">
+                      <button onClick={() => deleteCost(cost.id)} className="text-red-600 hover:text-red-800">
+                        <Trash className="h-4 w-4" />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Charts */}
+      {globalTotal > 0 && (
+        <div className="grid md:grid-cols-2 gap-6">
+          <div className="bg-white rounded-xl shadow-sm p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Évolution mensuelle 2025</h2>
+            <div className="h-80">
+              <Bar data={barData} options={{ responsive: true, maintainAspectRatio: false }} />
+            </div>
+          </div>
+          <div className="bg-white rounded-xl shadow-sm p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Répartition</h2>
+            <div className="h-80">
+              <Pie data={pieData} options={{ responsive: true, maintainAspectRatio: false }} />
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,6 +33,10 @@ export interface Cost {
   description: string;
   amount: number;
   category: 'office' | 'salaries' | 'charges' | 'subcontracting' | 'materials' | 'transport' | 'housing' | 'other';
+  /** Additional office-specific type (frais fixes, variables, salaires) */
+  officeType?: 'fixed' | 'variable' | 'payroll';
+  /** Detailed sub category label (e.g. Google, Essence...) */
+  officeCategory?: string;
   date: Date;
 }
 


### PR DESCRIPTION
## Summary
- extend `Cost` type with `officeType` and `officeCategory`
- rebuild `OfficeCosts` page with separate fixed, variable and payroll sections
- display monthly bar and pie charts for office expenses

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685916bd1ef4832da34f443ff5cf668f