### PR TITLE
Add 'Prime performance' payroll category

### DIFF
--- a/src/components/Costs/OfficeCosts.tsx
+++ b/src/components/Costs/OfficeCosts.tsx
@@ -53,7 +53,7 @@ const variableCategories = [
   'Autre'
 ];
 
-const payrollCategories = ['Salaire', 'Charges', 'Autre'];
+const payrollCategories = ['Salaire', 'Charges', 'Prime performance', 'Autre'];
 
 const OfficeCosts: React.FC = () => {
   const { costs, addCost, deleteCost } = useAppContext();


### PR DESCRIPTION
## Summary
- expand payroll categories in OfficeCosts with `Prime performance`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859192742bc832dae1b9d943d035c15