### PR TITLE
Add TVA category to variable costs

### DIFF
--- a/src/components/Costs/OfficeCosts.tsx
+++ b/src/components/Costs/OfficeCosts.tsx
@@ -50,6 +50,7 @@ const variableCategories = [
   'Outils',
   'Hôtel',
   'Vêtements',
+  'TVA',
   'Autre'
 ];
 


### PR DESCRIPTION
## Summary
- add new `TVA` option to the variable costs categories

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68591948469c832d9276454232a489ef