### PR TITLE
Add client dropdown to costs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ La barre latérale donne accès aux différentes pages :
 - **Dashboard** : synthèse des revenus, coûts et bénéfices.
 - **Clients** : gestion des clients (ajout, modification, suppression) et suivi du chiffre d'affaires par client.
 - **Factures** : création de factures et suivi de leur statut (payée, en attente ou en retard). Il est possible de lier un fichier PDF.
-- **Coûts** : enregistrement des dépenses par client ou générales.
+- **Coûts** : enregistrement des dépenses par client ou générales. Un menu déroulant en haut de la page permet désormais de sélectionner rapidement un client et d'afficher automatiquement ses coûts.
 - **Analytics** : graphiques et indicateurs pour visualiser la rentabilité.
 - **Reports** : génération d'un rapport annuel exportable au format PDF.
 

--- a/src/components/Costs/CostForm.tsx
+++ b/src/components/Costs/CostForm.tsx
@@ -6,12 +6,13 @@ import { Cost } from '../../types';
 interface CostFormProps {
   cost?: Cost | null;
   onClose: () => void;
+  defaultClientId?: string;
 }
 
-const CostForm: React.FC<CostFormProps> = ({ cost, onClose }) => {
+const CostForm: React.FC<CostFormProps> = ({ cost, onClose, defaultClientId }) => {
   const { clients, invoices, addCost, updateCost } = useAppContext();
   const [formData, setFormData] = useState({
-    clientId: cost?.clientId || '',
+    clientId: cost?.clientId || defaultClientId || '',
     invoiceId: cost?.invoiceId || '',
     description: cost?.description || '',
     amount: cost?.amount || 0,


### PR DESCRIPTION
## Summary
- move client filter to header as a dropdown
- filter costs using client id
- prefill CostForm with selected client
- document dropdown in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859dccdd26c832db795e5d32b479257