### PR TITLE
Add collapsible groups in costs view

### DIFF
--- a/src/components/Costs/CostsManager.tsx
+++ b/src/components/Costs/CostsManager.tsx
@@ -1,6 +1,19 @@
 import React, { useState } from 'react';
 import { format } from 'date-fns';
-import { Plus, Search, DollarSign, Users, FileText, Truck, Wrench, BarChart3, Home, Building2 } from 'lucide-react';
+import {
+  Plus,
+  Search,
+  DollarSign,
+  Users,
+  FileText,
+  Truck,
+  Wrench,
+  BarChart3,
+  Home,
+  Building2,
+  ChevronDown,
+  ChevronRight,
+} from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
 import CostForm from './CostForm';
 import { Cost } from '../../types';
@@ -12,6 +25,7 @@ const CostsManager: React.FC = () => {
   const [clientFilter, setClientFilter] = useState<string>('all');
   const [showForm, setShowForm] = useState(false);
   const [editingCost, setEditingCost] = useState<Cost | null>(null);
+  const [expandedClients, setExpandedClients] = useState<Record<string, boolean>>({});
 
   const categories = [
     { id: 'salaries', label: '👥 Salaires', icon: Users, color: 'text-blue-600', bg: 'bg-blue-50' },
@@ -59,6 +73,22 @@ const CostsManager: React.FC = () => {
     return invoices.find(inv => inv.id === invoiceId);
   };
 
+  const toggleClient = (clientId: string) => {
+    setExpandedClients(prev => ({ ...prev, [clientId]: !prev[clientId] }));
+  };
+
+  const expandAll = () => {
+    const all: Record<string, boolean> = {};
+    Object.keys(costsByClient).forEach(id => {
+      all[id] = true;
+    });
+    setExpandedClients(all);
+  };
+
+  const collapseAll = () => {
+    setExpandedClients({});
+  };
+
   const totalAmount = filteredCosts.reduce((sum, cost) => sum + cost.amount, 0);
 
   const costsByClient = filteredCosts.reduce<Record<string, { clientName: string; costs: Cost[] }>>((acc, cost) => {
@@ -104,6 +134,19 @@ const CostsManager: React.FC = () => {
               <option key={client.id} value={client.id}>{client.name}</option>
             ))}
           </select>
+
+          <button
+            onClick={expandAll}
+            className="px-2 py-2 border border-gray-300 rounded-lg text-sm hover:bg-gray-50"
+          >
+            Tout ouvrir
+          </button>
+          <button
+            onClick={collapseAll}
+            className="px-2 py-2 border border-gray-300 rounded-lg text-sm hover:bg-gray-50"
+          >
+            Tout fermer
+          </button>
 
           {currentUser?.role === 'admin' && (
             <button
@@ -201,17 +244,30 @@ const CostsManager: React.FC = () => {
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
-              {Object.values(costsByClient).map(group => (
-                <React.Fragment key={group.clientName}>
-                  <tr className="bg-gray-100">
-                    <td
-                      colSpan={currentUser?.role === 'admin' ? 7 : 6}
-                      className="px-6 py-3 text-left text-sm font-semibold text-gray-700"
+              {Object.entries(costsByClient).map(([clientId, group]) => {
+                const expanded = expandedClients[clientId];
+                return (
+                  <React.Fragment key={clientId}>
+                    <tr
+                      className="bg-gray-100 cursor-pointer"
+                      onClick={() => toggleClient(clientId)}
                     >
-                      {group.clientName}
-                    </td>
-                  </tr>
-                  {group.costs.map(cost => {
+                      <td
+                        colSpan={currentUser?.role === 'admin' ? 7 : 6}
+                        className="px-6 py-3 text-left text-sm font-semibold text-gray-700"
+                      >
+                        <div className="flex items-center space-x-2">
+                          {expanded ? (
+                            <ChevronDown className="w-4 h-4" />
+                          ) : (
+                            <ChevronRight className="w-4 h-4" />
+                          )}
+                          <span>{group.clientName}</span>
+                        </div>
+                      </td>
+                    </tr>
+                    {expanded &&
+                      group.costs.map(cost => {
                     const categoryInfo = getCategoryInfo(cost.category);
                     const Icon = categoryInfo.icon;
                     const invoiceInfo = getInvoiceInfo(cost.invoiceId);


### PR DESCRIPTION
## Summary
- allow opening/collapsing of cost rows per client
- add buttons to expand or collapse all cost groups

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6859e59f4940832dad12e533dd788526