### PR TITLE
Add cost grid management interface

### DIFF
--- a/server/data.json
+++ b/server/data.json
@@ -1,5 +1,6 @@
 {
   "clients": [],
   "invoices": [],
-  "costs": []
+  "costs": [],
+  "costGrids": []
 }

--- a/server/index.js
+++ b/server/index.js
@@ -80,11 +80,12 @@ function createRouter(key) {
 app.use('/clients', createRouter('clients'));
 app.use('/invoices', createRouter('invoices'));
 app.use('/costs', createRouter('costs'));
+app.use('/costGrids', createRouter('costGrids'));
 
 // Endpoint to replace the entire dataset (used for manual sync)
 app.post('/sync', requireAuth, (req, res) => {
-  const { clients = [], invoices = [], costs = [] } = req.body || {};
-  const data = { clients, invoices, costs };
+  const { clients = [], invoices = [], costs = [], costGrids = [] } = req.body || {};
+  const data = { clients, invoices, costs, costGrids };
   writeData(data);
   res.sendStatus(204);
 });

--- a/src/components/Costs/CostGridForm.tsx
+++ b/src/components/Costs/CostGridForm.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from 'react';
+import { X, LayoutGrid } from 'lucide-react';
+import { useAppContext } from '../../context/AppContext';
+import { CostGrid } from '../../types';
+
+interface CostGridFormProps {
+  onClose: () => void;
+}
+
+const CostGridForm: React.FC<CostGridFormProps> = ({ onClose }) => {
+  const { addCostGrid } = useAppContext();
+  const [form, setForm] = useState<{ name: string; category: string }>({
+    name: '',
+    category: ''
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.name.trim()) return;
+    const data: Omit<CostGrid, 'id'> = { ...form, clients: [] };
+    addCostGrid(data);
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white rounded-xl shadow-lg w-full max-w-sm">
+        <div className="flex items-center justify-between p-4 border-b border-gray-200">
+          <div className="flex items-center space-x-2">
+            <LayoutGrid className="h-5 w-5 text-blue-600" />
+            <h2 className="text-lg font-semibold text-gray-900">Nouvelle Grille</h2>
+          </div>
+          <button onClick={onClose} className="p-1 text-gray-400 hover:text-gray-600">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <form onSubmit={handleSubmit} className="p-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Nom *</label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              required
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Catégorie</label>
+            <input
+              type="text"
+              value={form.category}
+              onChange={(e) => setForm({ ...form, category: e.target.value })}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            />
+          </div>
+          <div className="flex justify-end">
+            <button type="submit" className="bg-primary-600 text-white px-4 py-2 rounded-lg hover:bg-primary-700">
+              Enregistrer
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default CostGridForm;

--- a/src/components/Costs/CostGridsManager.tsx
+++ b/src/components/Costs/CostGridsManager.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { ChevronDown, ChevronRight, Plus } from 'lucide-react';
+import { useAppContext } from '../../context/AppContext';
+import CostGridForm from './CostGridForm';
+
+const CostGridsManager: React.FC = () => {
+  const { costGrids, currentUser } = useAppContext();
+  const [search, setSearch] = useState('');
+  const [open, setOpen] = useState<Record<string, boolean>>({});
+  const [showForm, setShowForm] = useState(false);
+
+  const filtered = costGrids.filter(g =>
+    g.name.toLowerCase().includes(search.toLowerCase()) ||
+    (g.category || '').toLowerCase().includes(search.toLowerCase())
+  );
+
+  return (
+    <div className="mb-8">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-bold text-gray-900">Grilles de Coûts</h2>
+        {currentUser?.role === 'admin' && (
+          <button
+            onClick={() => setShowForm(true)}
+            className="flex items-center space-x-2 bg-primary-600 text-white px-3 py-2 rounded-lg hover:bg-primary-700"
+          >
+            <Plus className="h-4 w-4" />
+            <span>Nouvelle grille de coûts</span>
+          </button>
+        )}
+      </div>
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Rechercher une grille..."
+        className="w-full mb-4 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+      />
+      <div className="bg-white rounded-xl shadow-sm divide-y divide-gray-200">
+        {filtered.map(grid => (
+          <div key={grid.id}>
+            <button
+              className="w-full flex items-center justify-between px-4 py-3 text-left"
+              onClick={() => setOpen(prev => ({ ...prev, [grid.id]: !prev[grid.id] }))}
+            >
+              <div className="flex items-center gap-2">
+                {open[grid.id] ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                <span className="font-medium text-gray-900">{grid.name}</span>
+                {grid.category && <span className="text-sm text-gray-500">({grid.category})</span>}
+              </div>
+            </button>
+            {open[grid.id] && (
+              <div className="px-8 py-4 space-y-2 bg-gray-50">
+                {grid.clients.map(c => (
+                  <div key={c.clientId} className="flex items-center justify-between">
+                    <span className="text-gray-700">{c.clientName}{c.notes && <span className='text-xs text-gray-500 ml-2'>{c.notes}</span>}</span>
+                    <span className="font-semibold text-gray-900">{c.rate.toLocaleString('fr-FR')} €</span>
+                  </div>
+                ))}
+                {grid.clients.length === 0 && (
+                  <p className="text-sm text-gray-500">Aucun client associé</p>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+        {filtered.length === 0 && (
+          <div className="px-4 py-6 text-center text-gray-500">Aucune grille trouvée</div>
+        )}
+      </div>
+      {showForm && <CostGridForm onClose={() => setShowForm(false)} />}
+    </div>
+  );
+};
+
+export default CostGridsManager;

--- a/src/components/Costs/CostsManager.tsx
+++ b/src/components/Costs/CostsManager.tsx
@@ -3,6 +3,7 @@ import { format } from 'date-fns';
 import { Plus, Search, DollarSign, Users, FileText, Truck, Wrench, BarChart3, Home, Building2, ChevronDown, ChevronRight } from 'lucide-react';
 import { useAppContext } from '../../context/AppContext';
 import CostForm from './CostForm';
+import CostGridsManager from './CostGridsManager';
 import { Cost } from '../../types';
 
 const CostsManager: React.FC = () => {
@@ -95,6 +96,7 @@ const CostsManager: React.FC = () => {
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
+      <CostGridsManager />
       <div className="flex flex-col sm:flex-row sm:items-center justify-between mb-8 gap-4">
         <div>
           <h1 className="text-3xl font-bold text-gray-900 mb-2">🟦 Gestion des Coûts</h1>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -104,3 +104,17 @@ export interface ClientAnnualData {
   revenueShare: number;
   invoicesCount: number;
 }
+
+export interface CostGridClient {
+  clientId: string;
+  clientName: string;
+  rate: number;
+  notes?: string;
+}
+
+export interface CostGrid {
+  id: string;
+  name: string;
+  category?: string;
+  clients: CostGridClient[];
+}


### PR DESCRIPTION
## Summary
- support `costGrids` in server API and data
- define `CostGrid` and related types
- extend context to load and sync cost grids
- add `CostGridForm` and `CostGridsManager` components
- display cost grids in Costs manager page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1fa8d558832d988450494f51ea9a